### PR TITLE
Disable `HISTCONTROL=ignoreboth`

### DIFF
--- a/shell/exports/.env-vars
+++ b/shell/exports/.env-vars
@@ -15,7 +15,7 @@ export HISTFILE="$HOME/.bash_history" # Use "~/.bash_history" even on tmux
 export HISTSIZE=10000 # Number of history of current shell
 export HISTFILESIZE=10000 # Number of history of HISTFILE, shell-var
 export HISTTIMEFORMAT="%F %T " # Show timestamp running `history`. see `man strftime`
-export HISTCONTROL=ignoreboth # Not record the same command as the previous
+# export HISTCONTROL=ignoreboth # Not record the same command as the previous
 
 #[ Store tmux-session ]
 export TMUX_TMPDIR=/var/tmp


### PR DESCRIPTION
sometimes the previous command is wrong due to `sync_history` func