### PR TITLE
Enable `ssh`/`rsync` completion 

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -28,6 +28,9 @@ fi
 # See https://github.com/ohmyzsh/ohmyzsh/wiki/Themes
 ZSH_THEME="git-info"
 
+# cf. https://github.com/ohmyzsh/ohmyzsh/issues/12353
+zstyle ':omz:alpha:lib:git' async-prompt no
+
 # Uncomment the following line to use case-sensitive completion.
 # CASE_SENSITIVE="true"
 

--- a/.zshrc
+++ b/.zshrc
@@ -83,6 +83,8 @@ plugins=(
   laravel
   npm
   nvm
+  rsync
+  ssh
   terraform
   tmux
   zsh-syntax-highlighting
@@ -117,7 +119,3 @@ done
 if [[ -z "$TMUX" ]] && is_interactive_shell && is_login_shell && [[ -z "$VSCODE_INJECTION" ]]; then
   _zsh_tmux_plugin_run
 fi
-
-# zstyle ':completion:*:(ssh|rsync):*' ignored-patterns '*\#*'
-# zstyle ':completion:*:(ssh|rsync):*' hosts
-# zstyle ':completion:*:(ssh|rsync):*' users


### PR DESCRIPTION
As the latest OMZ include `ssh` and `rsync` plugin, apply it and enable their completions.

But somehow other mac terminal can use completion without this.
