### PR TITLE
Utilize Poetry virtual env

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -84,6 +84,7 @@ plugins=(
   npm
   nvm
   poetry
+  poetry-env
   rsync
   ssh
   terraform

--- a/shell/common/config/poetry.sh
+++ b/shell/common/config/poetry.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# cf. https://python-poetry.org/docs/configuration/#virtualenvsin-project
+# And use VSCode setting "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python".
+export POETRY_VIRTUALENVS_IN_PROJECT=true


### PR DESCRIPTION
Although a static python path is required for VSCode to detect the default Python interpreter by its setting `python.defaultInterpreterPath`, Poetry Python path will be dynamic in default.
One of the way to fix the path is to set env `POETRY_VIRTUALENVS_IN_PROJECT=true`.

When using with [pre-commit](https://pre-commit.com), an error saying "`pre-commit` not found" will sometimes be thrown .
To use `pre-commit` that is in the Poetry virtual env, activation is required.
Oy My Zsh plugin `poetry-env` do it when moving into the directory with venv.
