### PR TITLE
feat: Disable unused and annoying VSCode default keybindings 

### DIFF
--- a/vscode/config/keybindings.json
+++ b/vscode/config/keybindings.json
@@ -1,13 +1,30 @@
 [
+  //=========================================================
+  // Disable default
+  //=========================================================
+  // - System
   {
-    "key": "cmd+t",
-    "command": "workbench.action.switchWindow"
+    "key": "f1",
+    "command": "-workbench.action.showCommands"
   },
+  {
+    "key": "ctrl+w",
+    "command": "-workbench.action.switchWindow"
+  },
+  {
+    "key": "shift+cmd+c",
+    "command": "-workbench.action.terminal.openNativeConsole",
+    "when": "!terminalFocus"
+  },
+  // - Extensions
   {
     "key": "cmd+m",
     "command": "-markdown.extension.editing.toggleMath",
     "when": "editorLangId == 'markdown'"
   },
+  //=========================================================
+  // Enable custom (maybe disable default)
+  //=========================================================
   {
     "key": "ctrl+w",
     "command": "deleteWordPartLeft",


### PR DESCRIPTION
## Tips

To add the screen saver shortcut, use built-in Automator.app quick action.
Select `Start Screen Saver` from the side bar and save it.

<img width="1470" alt="Screenshot 2024-10-27 at 12 38 58" src="https://github.com/user-attachments/assets/f64e9ac8-cac0-49fb-8345-15ccdb32787b">

Then, it'll appear in `System Settings` > `Keyboard` > `Keyboard shortcuts...`

<img width="667" alt="Screenshot 2024-10-27 at 12 40 20" src="https://github.com/user-attachments/assets/c3b440d1-5265-473f-b2c3-a8bd6f2ee041">